### PR TITLE
Create app_img2table

### DIFF
--- a/app_img2table
+++ b/app_img2table
@@ -1,0 +1,19 @@
+from img2table.document import PDF
+from img2table.ocr import PaddleOCR
+
+# Instantiation of document
+doc = PDF("../PDF feature/test-extraction-pdf/pdf/EDS.pdf", 
+          pages=[0, 2],
+          detect_rotation=False,
+          pdf_text_extraction=True)
+
+# Instantiation of OCR
+ocr = PaddleOCR(lang="en")
+
+# Table extraction
+extracted_tables = doc.extract_tables(ocr=ocr,
+                                      implicit_rows=False,
+                                      borderless_tables=False,
+                                      min_confidence=50)
+
+print(extracted_tables) 


### PR DESCRIPTION
Creating test archive with img2table, (need to test all ocr), paddleOCR only available with python 3.10 or lower.  Img2table doc: https://github.com/xavctn/img2table